### PR TITLE
Fixing pooling issues

### DIFF
--- a/jumpscale/packages/owncloud/frontend/src/components/BalanceCard.vue
+++ b/jumpscale/packages/owncloud/frontend/src/components/BalanceCard.vue
@@ -32,6 +32,7 @@ export default {
     return {
       balance: null,
       message: "New deployments have been disabled because balance < 1000",
+      timer: "",
     };
   },
   methods: {
@@ -45,9 +46,17 @@ export default {
           console.log("Error! Could not reach the API. " + error);
         });
     },
+    cancelAutoUpdate () {
+            clearInterval(this.timer);
+            this.timer = "";
+    },
   },
-  mounted() {
+  created() {
     this.getBalance();
+    this.timer = setInterval(this.getRequests, 10000);
+  },
+  destroyed() {
+    this.cancelAutoUpdate();
   },
 };
 </script>

--- a/jumpscale/packages/owncloud/frontend/src/views/Requests.vue
+++ b/jumpscale/packages/owncloud/frontend/src/views/Requests.vue
@@ -110,6 +110,7 @@ export default {
       balance: null,
       dialog: false,
       message: "",
+      timer: "",
     };
   },
   methods: {
@@ -136,21 +137,6 @@ export default {
         .catch((error) => {
           console.log("Error! Could not reach the API. " + error);
         })
-        .finally(() => {
-          if (
-            this.requests.some(
-              (item) =>
-                item.status !== "DEPLOYED" &&
-                item.status !== "APPLY_FAILURE" &&
-                item.status !== "EXPIRED" &&
-                item.status !== "NEW"
-            )
-          ) {
-            setInterval(() => {
-              this.getRequests();
-            }, 10000);
-          }
-        });
     },
     deploy(list) {
       if (list.length == 0) {
@@ -253,6 +239,10 @@ export default {
         this.message = value.error_message;
       }
     },
+    cancelAutoUpdate () {
+            clearInterval(this.timer);
+            this.timer = "";
+    }
   },
   computed: {
     requestsWithIndex() {
@@ -262,8 +252,12 @@ export default {
       }));
     },
   },
-  mounted() {
+  created() {
     this.getRequests();
+    this.timer = setInterval(this.getRequests, 10000);
+  },
+  destroyed() {
+    this.cancelAutoUpdate();
   },
 };
 </script>


### PR DESCRIPTION
fixing https://github.com/threefoldtech/www_owncloud/issues/16

**changes**:

- now refreshing is done in a consistent manner every 10 sec.
- pooling based on timing only, no matter what the deployment status, this improves the UX, E,g. deployed time are updated, new requests are shown, etc.
- adding a pooling to the balance widget as well.