### PR TITLE
Automate package configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,13 +25,14 @@ jumpscale based package for owncloud 3 month fremuim deployment
 ### Docker
 
 ```bash
-docker run -ti --name owncloud -e domain='<domain_name>' -e email_host='<mail_server_hostname>' -e email_port=<port> -e email_username='<email>' -e email_password='<password>' -e MNEMONICS='<MNEMONICS>' -e CHAIN_URL='wss://tfchain.dev.grid.tf/ws' -e NETWORK='dev' -e ADMINS="['<3bot_name>']" -e ALERT_EMAIL='<support_mail_address>' -e SUPPORT_PUBLIC_SSH_KEY='<public ssh key>' -e RESTIC_REPOSITORY='<RESTIC_REPOSITORY_URL>' -e RESTIC_PASSWORD='<RESTIC_REPOSITORY_PASSWORD>' -e AWS_ACCESS_KEY_ID='<MY_ACCESS_KEY_ID>' -e AWS_SECRET_ACCESS_KEY='<MY_SECRET_ACCESS_KEY>' -p 80:80 -p 443:443 threefolddev/owncloud_deployer:latest
+docker run -ti --name owncloud -e domain='<domain_name>' -e letsencryptemail='<email_address>' -e email_host='<mail_server_hostname>' -e email_port=<port> -e email_username='<email>' -e email_password='<password>' -e MNEMONICS='<MNEMONICS>' -e CHAIN_URL='wss://tfchain.dev.grid.tf/ws' -e NETWORK='dev' -e ADMINS="['<3bot_name>']" -e ALERT_EMAIL='<support_mail_address>' -e SUPPORT_PUBLIC_SSH_KEY='<public ssh key>' -e RESTIC_REPOSITORY='<RESTIC_REPOSITORY_URL>' -e RESTIC_PASSWORD='<RESTIC_REPOSITORY_PASSWORD>' -e AWS_ACCESS_KEY_ID='<MY_ACCESS_KEY_ID>' -e AWS_SECRET_ACCESS_KEY='<MY_SECRET_ACCESS_KEY>' -p 80:80 -p 443:443 threefolddev/owncloud_deployer:latest
 ```
 
 #### ENV VARS 
 ##### js-sdk env:
   
-- `domain`: domain of the site which will host the package (done in package.toml).
+- `domain`: domain of the site which will host the package.
+- `letsencryptemail`: let's Encrypt admin email to receive expiry notices when your certificate is coming up for renewal.
 - `email_host`, `email_port`, `email_username`, `email_password`: configurations of mail server.
 - `ADMINS`: list of system admins (3bot names) that will manage requests.
 - `ALERT_EMAIL`: email which will receive wallet alerts.

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ jsng
 ident=j.core.identity.new("default", "ownclouddeployertest10.3bot", "ownclouddeployertest10@incubaid.com", network="testnet", admins=["samehabouelsaad.3bot"]); ident.register(); ident.save()
 j.servers.threebot.new("default"); j.servers.threebot.default.save()
 j.core.config.set("EMAIL_SERVER_CONFIG", {'host': 'smtp.gmail.com', 'port': '587', 'username': '', 'password': ''}) 
-j.servers.threebot.default.packages.add(path='/root/owncloud_deployer/jumpscale/packages/owncloud')
+j.servers.threebot.default.packages.add(path='/root/owncloud_deployer/jumpscale/packages/owncloud', domain=<domain>, letsencryptemail=<letsencryptemail>)
 ```
 
 13 - start the server

--- a/docker/init.sh
+++ b/docker/init.sh
@@ -15,8 +15,6 @@ fi
 # link model to presistent volume
 mkdir -p /data/jsngmodel && ln -s /data/jsngmodel ~/.config/jumpscale
 
-# Edit the default domain with the passed one
-sed -i "s/domain = \"waleed.threefold.io\"/domain = \"$domain\"/g" /owncloud_deployer/jumpscale/packages/owncloud/package.toml 
 
 # Edit the default support ssh key with the passed one
 [[ ! -z "${SUPPORT_PUBLIC_SSH_KEY}" ]] && sed -i "s:\"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDSkhNAIP22RH/sQx7alFS6vcqw1OAQUkC5MLv6t3L78YVTRv+/owSqIqCQHr2+zfb3aJijsxj9nqg54rVkEiCXOkT6IE/MGWSP6O/x/cCG8J7AT+OCCjo9IB/+V3CA8yREHi7ggqPv6hEfNoa1AMbnxqxT7a+5sJUVd14/Ib9OQKWBCXzosa0SjTY/RO1SrL93E80N+SJQRBCMemzlepn4wLDWvqs7DiruY+g9E2CskhDijt4iJCuNFZzAcTS3UeqxOG2QfLK2zc8M9/AycMcEyHn94Lml6V75Lk09iLB9QGTGsa4oAD3GFLce4VoKKZx0e6lwwnMNoAHKhBEMFmO5 root@waleed-ng\":\"$SUPPORT_PUBLIC_SSH_KEY\":g" /root/tf_source_module/main.tf
@@ -30,6 +28,9 @@ jsng "j.servers.threebot.default.packages.add(path='/owncloud_deployer/jumpscale
 
 # Set email server config
 jsng "email_server_config = {\"host\": \"$email_host\", \"port\": "$email_port", \"username\": \"$email_username\", \"password\": \"$email_password\"}; j.core.config.set(\"EMAIL_SERVER_CONFIG\", email_server_config)"
+
+# Configure the package, make sure to set domain and letsencryptemail as env variables
+python3 docker/rootfs/scripts/configure_package.py owncloud $domain $letsencryptemail
 
 # Configure restic client for backup
 echo "Backup configuration started"

--- a/docker/init.sh
+++ b/docker/init.sh
@@ -15,7 +15,6 @@ fi
 # link model to presistent volume
 mkdir -p /data/jsngmodel && ln -s /data/jsngmodel ~/.config/jumpscale
 
-
 # Edit the default support ssh key with the passed one
 [[ ! -z "${SUPPORT_PUBLIC_SSH_KEY}" ]] && sed -i "s:\"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDSkhNAIP22RH/sQx7alFS6vcqw1OAQUkC5MLv6t3L78YVTRv+/owSqIqCQHr2+zfb3aJijsxj9nqg54rVkEiCXOkT6IE/MGWSP6O/x/cCG8J7AT+OCCjo9IB/+V3CA8yREHi7ggqPv6hEfNoa1AMbnxqxT7a+5sJUVd14/Ib9OQKWBCXzosa0SjTY/RO1SrL93E80N+SJQRBCMemzlepn4wLDWvqs7DiruY+g9E2CskhDijt4iJCuNFZzAcTS3UeqxOG2QfLK2zc8M9/AycMcEyHn94Lml6V75Lk09iLB9QGTGsa4oAD3GFLce4VoKKZx0e6lwwnMNoAHKhBEMFmO5 root@waleed-ng\":\"$SUPPORT_PUBLIC_SSH_KEY\":g" /root/tf_source_module/main.tf
 
@@ -24,13 +23,12 @@ jsng "ident=j.core.identity.new(\"default\", \"$dummy_tname\", \"$dummy_email\",
 
 # Create the default threebot
 jsng 'j.servers.threebot.new("default"); j.servers.threebot.default.save()'
-jsng "j.servers.threebot.default.packages.add(path='/owncloud_deployer/jumpscale/packages/owncloud')"
+
+# Add and Configure the package, make sure to set domain and letsencryptemail as env variables
+jsng "j.servers.threebot.default.packages.add(path=\"/owncloud_deployer/jumpscale/packages/owncloud\", domain=\"$domain\", letsencryptemail=\"$letsencryptemail\")"
 
 # Set email server config
 jsng "email_server_config = {\"host\": \"$email_host\", \"port\": "$email_port", \"username\": \"$email_username\", \"password\": \"$email_password\"}; j.core.config.set(\"EMAIL_SERVER_CONFIG\", email_server_config)"
-
-# Configure the package, make sure to set domain and letsencryptemail as env variables
-python3 docker/rootfs/scripts/configure_package.py owncloud $domain $letsencryptemail
 
 # Configure restic client for backup
 echo "Backup configuration started"

--- a/jumpscale/packages/owncloud/package.py
+++ b/jumpscale/packages/owncloud/package.py
@@ -1,0 +1,25 @@
+import toml
+
+PACKAGE_CONFIG_PATH = 'package.toml'
+
+class owncloud:
+    def install(self, **kwargs):
+        domain = kwargs.get('domain')
+        letsencryptemail = kwargs.get('letsencryptemail')
+        if not all([domain, letsencryptemail]):
+            raise(f'usage: j.servers.threebot.default.packages.add(path="<package_path>", domain="<domain>", letsencryptemail="<letsencryptemail>")')
+        
+        with open(PACKAGE_CONFIG_PATH, 'rt') as f:
+            parsed_toml = toml.load(f)
+        
+        if domain:
+            parsed_toml['servers'][0]['domain'] = domain
+            print(f"set the domain to {domain}")
+
+        if letsencryptemail:
+            parsed_toml['servers'][0]['letsencryptemail'] = letsencryptemail
+            print(f"set the email to {letsencryptemail}")
+
+        with open(PACKAGE_CONFIG_PATH, 'wt') as f:
+            _ = toml.dump(parsed_toml, f)
+        print('Package installation complete!')

--- a/jumpscale/packages/owncloud/package.py
+++ b/jumpscale/packages/owncloud/package.py
@@ -1,25 +1,28 @@
+from jumpscale.loader import j
+from jumpscale.sals.fs import pathlib
 import toml
-from pathlib import Path
 
-PACKAGE_CONFIG_PATH = Path(__file__).parent.resolve() / 'package.toml'
+PACKAGE_CONFIG_PATH = pathlib.Path(__file__).parent.resolve() / 'package.toml'
 class owncloud:
     def install(self, **kwargs):
         domain = kwargs.get('domain')
         letsencryptemail = kwargs.get('letsencryptemail')
+        j.logger.debug('Installing owncloud package..')
         if not all([domain, letsencryptemail]):
-            raise(f'usage: j.servers.threebot.default.packages.add(path="<package_path>", domain="<domain>", letsencryptemail="<letsencryptemail>")')
+            j.logger.warning('One or more required parameters missing. Please provide domain and letsencryptemail')
+            j.logger.warning(f'Usage: j.servers.threebot.default.packages.add(path="<package_path>", domain="<domain>", letsencryptemail="<letsencryptemail>")')
         
         with open(PACKAGE_CONFIG_PATH, 'rt') as f:
             parsed_toml = toml.load(f)
         
         if domain:
             parsed_toml['servers'][0]['domain'] = domain
-            print(f"set the domain to {domain}")
+            j.logger.debug(f"set the domain to {domain}")
 
         if letsencryptemail:
             parsed_toml['servers'][0]['letsencryptemail'] = letsencryptemail
-            print(f"set the email to {letsencryptemail}")
+            j.logger.debug(f"set the email to {letsencryptemail}")
 
         with open(PACKAGE_CONFIG_PATH, 'wt') as f:
             _ = toml.dump(parsed_toml, f)
-        print('Package installation complete!')
+        j.logger.info('owncloud package installed successfully!')

--- a/jumpscale/packages/owncloud/package.py
+++ b/jumpscale/packages/owncloud/package.py
@@ -1,7 +1,7 @@
 import toml
+from pathlib import Path
 
-PACKAGE_CONFIG_PATH = 'package.toml'
-
+PACKAGE_CONFIG_PATH = Path(__file__).parent.resolve() / 'package.toml'
 class owncloud:
     def install(self, **kwargs):
         domain = kwargs.get('domain')

--- a/jumpscale/packages/owncloud/package.toml
+++ b/jumpscale/packages/owncloud/package.toml
@@ -20,8 +20,8 @@ host = "0.0.0.0"
 
 [[servers]]
 name = "owncloud"
-domain = "waleed.threefold.io"
-letsencryptemail = "hammamw@incubaid.com"
+domain = ""
+letsencryptemail = ""
 includes = ["default_443.chatflows_*", "default_443.auth_*", "default_443.owncloud*"]
 
 [[servers.locations]]


### PR DESCRIPTION
What's new:
- set the let's encrypt admin mail by passing an Env variable to the image run command.

What's changed:
- setting the domain and mail done in the Owncloud package's `install` method, instead of relying on sed to replace the default domain in the Owncloud package's `package.toml` file. also, the domain and mail have now defaulted to an empty string.
- Docs Updated.

Related Issue:
- #22 
