### PR TITLE
Fixing scheduler sru unit

### DIFF
--- a/docker/tf_source_module/main.tf
+++ b/docker/tf_source_module/main.tf
@@ -46,7 +46,7 @@ resource "grid_scheduler" "sched" {
   requests {
     name = local.server_req
     cru = local.vm_cpu
-    sru = local.disk_size + local.rootfs_size
+    sru = (local.disk_size + local.rootfs_size) * 1024
     mru = local.vm_memory
   }
 


### PR DESCRIPTION
modify scheduler `sru` request Unit to use MB instead of GB, as per the Terraform grid plugin [Docs](https://github.com/threefoldtech/terraform-provider-grid/blob/development/docs/resources/scheduler.md#nested-schema-for-requests )
